### PR TITLE
Handle user responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When the user clicks either of the buttons, the app should:
 * send a request to the server to record the user's response.
 
 The endpoint to update the server does not exist yet. You should create one that records the user's response in the
-`ststus` field of the relevant word part record.
+`status` field of the relevant word part record.
 
 When refreshing the page or selecting a different level, the app should correctly colour the user's responses in the
 list of word parts.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.0.4",
+        "@tanstack/react-query": "^5.90.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tailwindcss": "^4.0.4"
@@ -1643,6 +1644,30 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.0.4",
+    "@tanstack/react-query": "^5.90.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwindcss": "^4.0.4"

--- a/client/src/components/LevelSelector.tsx
+++ b/client/src/components/LevelSelector.tsx
@@ -1,43 +1,50 @@
-import {useEffect, useState} from "react";
-import WordPartsList from "./WordPartsList.tsx";
-import {Level} from "../types/Level.ts";
+import { useState } from "react";
+import WordPartsList from "./WordPartsList";
+import { Level } from "../types/Level";
+import { useLevels } from "../queries/levels";
 
 /** A component that displays a level selector, whose values are loaded from the /phonics_levels endpoint.
  * The current level default to null, and is updated when the user selects a new level.
  * That new level then triggers a fetch to the /phonics_levels/:id/word_parts endpoint, which is used to update the content of the page.
  */
 const LevelSelector = () => {
-  const [levels, setLevels] = useState<Level[]>([]);
   const [level, setLevel] = useState<string>("");
+  const [levels, setLevels] = useState<Level[]>([]);
+  const { data, isLoading, isError, error, isSuccess } = useLevels();
 
-  useEffect(() => {
-    // load levels from http://localhost:3000/phonics_levels
-    fetch("/phonics_levels")
-      .then((response) => response.json())
-      .then((data) => {
-        setLevels(data as Level[]);
-      })
-      .catch((error) => { console.error("Error fetching levels", error); });
-  }, []);
+  if (isSuccess && data && levels.length === 0) {
+    setLevels(data);
+  }
 
   return (
     <div>
       <h1 className="text-2xl my-4">Phonics Level</h1>
-      <select
-        value={level}
-        onChange={(e) => {
-          setLevel(e.target.value);
-        }}
-        className="w-full mb-4"
-      >
-        <option value="">Select a level</option>
-        {levels.map((level) => (
-          <option value={level.id} key={level.id}>
-            Level {level.level_number}
-          </option>
-        ))}
-      </select>
+
+      {isLoading && <div>Loading...</div>}
+
+      {isError && <div>Error: {(error as Error).message}</div>}
+
+      {!isLoading && !isError && levels.length === 0 && (
+        <div>No levels found.</div>
+      )}
+
+      {levels.length > 0 &&
+        <select
+          value={level}
+          onChange={(e) => {
+            setLevel(e.target.value);
+          }}
+          className="w-full mb-4"
+        >
+          <option value="">Select a level</option>
+          {levels.map((level) => (
+            <option value={level.id} key={level.id}>
+              Level {level.level_number}
+            </option>
+          ))}
+        </select>}
       <hr />
+
       {level && <WordPartsList levelId={level} />}
     </div>
   );

--- a/client/src/components/LevelSelector.tsx
+++ b/client/src/components/LevelSelector.tsx
@@ -8,7 +8,7 @@ import { useLevels } from "../queries/levels.query";
  * That new level then triggers a fetch to the /phonics_levels/:id/word_parts endpoint, which is used to update the content of the page.
  */
 export default function LevelSelector() {
-  const [level, setLevel] = useState<string>("");
+  const [level, setLevel] = useState<number | null>(null);
   const [levels, setLevels] = useState<Level[]>([]);
   const { data, isLoading, isError, error, isSuccess } = useLevels();
 
@@ -16,8 +16,8 @@ export default function LevelSelector() {
     setLevels(data);
   }
 
-  const handleLevelChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setLevel(e.target.value);
+  const handleLevelChange = (level: number) => {
+    setLevel(level);
   }
 
   return (
@@ -32,21 +32,15 @@ export default function LevelSelector() {
         <div>No levels found.</div>
       )}
 
-      {levels.length > 0 &&
-        <select
-          value={level}
-          onChange={handleLevelChange}
-          className="w-full mb-4"
-        >
-          <option value="">Select a level</option>
-          {levels.map((level) => (
-            <option value={level.id} key={level.id}>
-              Level {level.level_number}
-            </option>
-          ))}
-        </select>}
+      {levels.length > 0 && <div>
+        <h2 className="text-xl mb-4">Selected Level:</h2>
+        {levels.map((item) => {
+          return (<button key={item.id} type="button"
+            className={`mr-2 mb-2 px-2 py-1 border rounded hover:bg-gray-200 cursor-pointer ${(level != null && level >= item.id) ? 'bg-blue-600 text-white' : ''}`}
+            onClick={() => handleLevelChange(item.id)}>{item.id}</button>)
+        })}
+      </div>}
       <hr />
-
       {level && <WordPartsList levelId={level} />}
     </div>
   );

--- a/client/src/components/LevelSelector.tsx
+++ b/client/src/components/LevelSelector.tsx
@@ -1,19 +1,23 @@
 import { useState } from "react";
 import WordPartsList from "./WordPartsList";
 import { Level } from "../types/Level";
-import { useLevels } from "../queries/levels";
+import { useLevels } from "../queries/levels.query";
 
 /** A component that displays a level selector, whose values are loaded from the /phonics_levels endpoint.
  * The current level default to null, and is updated when the user selects a new level.
  * That new level then triggers a fetch to the /phonics_levels/:id/word_parts endpoint, which is used to update the content of the page.
  */
-const LevelSelector = () => {
+export default function LevelSelector() {
   const [level, setLevel] = useState<string>("");
   const [levels, setLevels] = useState<Level[]>([]);
   const { data, isLoading, isError, error, isSuccess } = useLevels();
 
   if (isSuccess && data && levels.length === 0) {
     setLevels(data);
+  }
+
+  const handleLevelChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setLevel(e.target.value);
   }
 
   return (
@@ -31,9 +35,7 @@ const LevelSelector = () => {
       {levels.length > 0 &&
         <select
           value={level}
-          onChange={(e) => {
-            setLevel(e.target.value);
-          }}
+          onChange={handleLevelChange}
           className="w-full mb-4"
         >
           <option value="">Select a level</option>
@@ -49,5 +51,3 @@ const LevelSelector = () => {
     </div>
   );
 }
-
-export default LevelSelector;

--- a/client/src/components/WordPartDetail.spec.tsx
+++ b/client/src/components/WordPartDetail.spec.tsx
@@ -1,18 +1,18 @@
-import {describe, expect, it, vi} from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import WordPartDetail from "./WordPartDetail.tsx";
-import {fireEvent, render, screen} from "@testing-library/react";
-import {WordPart} from "../types/WordPart.ts";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { WordPart } from "../types/WordPart.ts";
 
 describe("WordPartDetail", () => {
     it("calls the onNeedsWork callback when the Needs Work button is clicked", () => {
         const onNeedsWork = vi.fn();
         const onMastered = vi.fn();
 
-        const wordPart: WordPart = {id: 1, label: "test"};
+        const wordPart: WordPart = { id: 1, label: "test", phonics_level_id: 1 };
 
-        render(<WordPartDetail wordPart={wordPart} onMastered={onMastered} onNeedsWork={onNeedsWork}/>);
+        render(<WordPartDetail wordPart={wordPart} onMastered={onMastered} onNeedsWork={onNeedsWork} />);
 
-        const needsWorkButton = screen.getByRole("button", {name: "Needs work" });
+        const needsWorkButton = screen.getAllByText("Needs work")[0];
         fireEvent.click(needsWorkButton);
 
         expect(onNeedsWork).toHaveBeenCalled();
@@ -22,12 +22,15 @@ describe("WordPartDetail", () => {
         const onNeedsWork = vi.fn();
         const onMastered = vi.fn();
 
-        const wordPart: WordPart = {id: 1, label: "test"};
+        const wordPart: WordPart = { id: 1, label: "test", phonics_level_id: 1 };
 
-        render(<WordPartDetail wordPart={wordPart} onMastered={onMastered} onNeedsWork={onNeedsWork}/>);
+        render(<WordPartDetail wordPart={wordPart} onMastered={onMastered} onNeedsWork={onNeedsWork} />);
 
-        const masteredButton = screen.getByRole("button", {name: "Needs work" });
-        fireEvent.click(masteredButton);
+        screen.getAllByRole("button").map((button) => {
+            if (button.textContent === "Got it!") {
+                return button.click();
+            }
+        });
 
         expect(onMastered).toHaveBeenCalled();
     });

--- a/client/src/components/WordPartDetail.tsx
+++ b/client/src/components/WordPartDetail.tsx
@@ -8,13 +8,13 @@ interface LargeWordPartProps {
 
 export default function WordPartDetail({ wordPart, onNeedsWork, onMastered }: LargeWordPartProps) {
   return (
-    <div className="w-full flex flex-col gap-6 justify-center items-center mt-8">
-      <span data-testid="largeWordPart" className="text-6xl">
+    <div className="w-full flex flex-col gap-6 justify-center items-center my-4">
+      <div data-testid="largeWordPart" className={`w-full text-center p-4 rounded text-6xl bg-gray-400 text-white ${wordPart.status === 'mastered' ? 'bg-green-400' : ''} ${wordPart.status === 'needs_work' ? 'bg-red-400' : ''}`}>
         {wordPart.label}
-      </span>
+      </div>
       <div className="flex flex-row w-full justify-between my-4">
-        <button type="button" onClick={onNeedsWork} className="w-[120px] px-4 py-2 bg-red-500 text-white rounded hover:bg-green-600">Needs work</button>
-        <button type="button" onClick={onMastered} className="w-[120px] px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600">Got it!</button>
+        <button type="button" onClick={onNeedsWork} className="w-[120px] px-4 py-2 bg-red-500 text-white rounded hover:bg-gray-600">Needs work</button>
+        <button type="button" onClick={onMastered} className="w-[120px] px-4 py-2 bg-green-500 text-white rounded hover:bg-gray-600">Got it!</button>
       </div>
     </div>
   )

--- a/client/src/components/WordPartDetail.tsx
+++ b/client/src/components/WordPartDetail.tsx
@@ -1,5 +1,4 @@
-import { WordPart } from "../types/WordPart.ts";
-import { FC } from "react";
+import { WordPart } from "../types/WordPart";
 
 interface LargeWordPartProps {
   wordPart: WordPart;
@@ -7,7 +6,7 @@ interface LargeWordPartProps {
   onMastered: () => void;
 }
 
-const WordPartDetail: FC<LargeWordPartProps> = ({ wordPart, onNeedsWork, onMastered }) => {
+export default function WordPartDetail({ wordPart, onNeedsWork, onMastered }: LargeWordPartProps) {
   return (
     <div className="w-full flex flex-col gap-6 justify-center items-center mt-8">
       <span data-testid="largeWordPart" className="text-6xl">
@@ -18,7 +17,5 @@ const WordPartDetail: FC<LargeWordPartProps> = ({ wordPart, onNeedsWork, onMaste
         <button type="button" onClick={onMastered} className="w-[120px] px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600">Got it!</button>
       </div>
     </div>
-  );
-};
-
-export default WordPartDetail;
+  )
+}

--- a/client/src/components/WordPartDetail.tsx
+++ b/client/src/components/WordPartDetail.tsx
@@ -1,5 +1,5 @@
-import {WordPart} from "../types/WordPart.ts";
-import {FC} from "react";
+import { WordPart } from "../types/WordPart.ts";
+import { FC } from "react";
 
 interface LargeWordPartProps {
   wordPart: WordPart;
@@ -7,15 +7,15 @@ interface LargeWordPartProps {
   onMastered: () => void;
 }
 
-const WordPartDetail: FC<LargeWordPartProps> = ({wordPart, onNeedsWork, onMastered}) => {
+const WordPartDetail: FC<LargeWordPartProps> = ({ wordPart, onNeedsWork, onMastered }) => {
   return (
     <div className="w-full flex flex-col gap-6 justify-center items-center mt-8">
-    <span data-testid="largeWordPart" className="text-6xl">
-      {wordPart.label}
-    </span>
+      <span data-testid="largeWordPart" className="text-6xl">
+        {wordPart.label}
+      </span>
       <div className="flex flex-row w-full justify-between my-4">
-        <button type="button" onClick={onNeedsWork} className="px-4 py-2 bg-red-500 text-white rounded hover:bg-green-600">Needs work</button>
-        <button type="button" onClick={onMastered} className="px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600">Got it!</button>
+        <button type="button" onClick={onNeedsWork} className="w-[120px] px-4 py-2 bg-red-500 text-white rounded hover:bg-green-600">Needs work</button>
+        <button type="button" onClick={onMastered} className="w-[120px] px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600">Got it!</button>
       </div>
     </div>
   );

--- a/client/src/components/WordPartsList.tsx
+++ b/client/src/components/WordPartsList.tsx
@@ -4,13 +4,13 @@ import WordPartDetail from "./WordPartDetail";
 import { useWordPartMut, useWordParts } from "../queries/wordPart.query";
 
 interface WordPartsViewProps {
-  levelId: string;
+  levelId: number;
 }
 
 export default function WordPartsList({ levelId }: WordPartsViewProps) {
   const [wordParts, setWordParts] = useState<WordPart[]>([]);
   const [selectedWordPart, setSelectedWordPart] = useState<WordPart | null>(null);
-  const { data, isLoading, isError, error, isSuccess } = useWordParts(Number(levelId));
+  const { data, isLoading, isError, error, isSuccess } = useWordParts(levelId);
   const { mutate, isError: isErrorMutation } = useWordPartMut();
 
   if (isSuccess && data) {

--- a/client/src/components/WordPartsList.tsx
+++ b/client/src/components/WordPartsList.tsx
@@ -13,8 +13,21 @@ export default function WordPartsList({ levelId }: WordPartsViewProps) {
   const { data, isLoading, isError, error, isSuccess } = useWordParts(Number(levelId));
   const { mutate, isError: isErrorMutation } = useWordPartMut();
 
-  if (isSuccess && data && wordParts.length === 0) {
-    setWordParts(data);
+  if (isSuccess && data) {
+    // on level change, clear word parts if no data
+    if (data.length === 0 && wordParts.length > 0) {
+      setWordParts([]);
+      setSelectedWordPart(null);
+    }
+    // on initial load, set word parts
+    else if (data.length > 0 && wordParts.length === 0) {
+      setWordParts(data);
+    }
+    // on level change, reset word parts and selected word part
+    else if (data.length > 0 && wordParts.length > 0 && data[0].id !== wordParts[0].id) {
+      setWordParts(data);
+      setSelectedWordPart(null);
+    }
   }
 
   const handleWordPartClick = (wordPartId: number) => {
@@ -29,7 +42,7 @@ export default function WordPartsList({ levelId }: WordPartsViewProps) {
   const handleNeedsWork = () => {
     mutate({
       ...selectedWordPart!,
-      status: "needs_practice"
+      status: "needs_work"
     }, {
       onSuccess: handleActionCallback,
     });
@@ -52,15 +65,13 @@ export default function WordPartsList({ levelId }: WordPartsViewProps) {
 
       {isError && <div>Error: {(error as Error).message}</div>}
 
-
-
       {!isLoading && !isError && wordParts.length === 0 && (
         <div>No word parts found for this level.</div>
       )}
 
       {wordParts.map((wordPart) => (
         <button key={wordPart.id} type="button"
-          className="mr-2 mb-2 px-2 py-1 border rounded hover:bg-gray-200 cursor-pointer"
+          className={`mr-2 mb-2 px-2 py-1 border rounded hover:bg-gray-200 cursor-pointer ${wordPart.status === 'mastered' ? 'bg-green-600 text-white' : ''} ${wordPart.status === 'needs_work' ? 'bg-red-500 text-white' : ''}`}
           onClick={() => handleWordPartClick(wordPart.id)}>{wordPart.label}</button>
       ))}
 

--- a/client/src/components/WordPartsList.tsx
+++ b/client/src/components/WordPartsList.tsx
@@ -1,52 +1,78 @@
-import {FC, useEffect, useState} from "react";
-import {WordPart} from "../types/WordPart.ts";
-import WordPartDetail from "./WordPartDetail.tsx";
+import { useState } from "react";
+import { WordPart } from "../types/WordPart";
+import WordPartDetail from "./WordPartDetail";
+import { useWordPartMut, useWordParts } from "../queries/wordPart.query";
 
 interface WordPartsViewProps {
   levelId: string;
 }
 
-const WordPartsList: FC<WordPartsViewProps> = ({levelId}) => {
+export default function WordPartsList({ levelId }: WordPartsViewProps) {
   const [wordParts, setWordParts] = useState<WordPart[]>([]);
   const [selectedWordPart, setSelectedWordPart] = useState<WordPart | null>(null);
+  const { data, isLoading, isError, error, isSuccess } = useWordParts(Number(levelId));
+  const { mutate, isError: isErrorMutation } = useWordPartMut();
 
-  useEffect(() => {
-    // load word parts from http://localhost:3000/phonics_levels/:id/word_parts
-    fetch(`/phonics_levels/${levelId}/word_parts`)
-      .then((response) => response.json())
-      .then((data) => {
-        setWordParts(data as WordPart[]);
-      })
-      .catch((error) => {
-        console.error("Error fetching word parts", error);
-      });
-  }, [levelId]);
+  if (isSuccess && data && wordParts.length === 0) {
+    setWordParts(data);
+  }
 
   const handleWordPartClick = (wordPartId: number) => {
     setSelectedWordPart(wordParts.find((wordPart) => wordPart.id === wordPartId) || null);
   }
 
+  const handleActionCallback = (updatedWordPart: WordPart) => {
+    setSelectedWordPart(updatedWordPart);
+    setWordParts(wordParts.map((wp) => wp.id === updatedWordPart.id ? updatedWordPart : wp));
+  }
+
   const handleNeedsWork = () => {
-    // TODO
+    mutate({
+      ...selectedWordPart!,
+      status: "needs_practice"
+    }, {
+      onSuccess: handleActionCallback,
+    });
   }
 
   const handleMastered = () => {
-    // TODO
+    mutate({
+      ...selectedWordPart!,
+      status: "mastered"
+    }, {
+      onSuccess: handleActionCallback,
+    });
   }
 
   return (
     <div className="my-4">
       <h2 className="text-xl mb-4">Word Parts</h2>
+
+      {isLoading && <div className="mr-2 mb-2 px-2 py-1 border rounded hover:bg-gray-200 cursor-pointer">Loading...</div>}
+
+      {isError && <div>Error: {(error as Error).message}</div>}
+
+
+
+      {!isLoading && !isError && wordParts.length === 0 && (
+        <div>No word parts found for this level.</div>
+      )}
+
       {wordParts.map((wordPart) => (
         <button key={wordPart.id} type="button"
-                className="mr-2 mb-2 px-2 py-1 border rounded hover:bg-gray-200 cursor-pointer"
-                onClick={() => handleWordPartClick(wordPart.id)}>{wordPart.label}</button>
+          className="mr-2 mb-2 px-2 py-1 border rounded hover:bg-gray-200 cursor-pointer"
+          onClick={() => handleWordPartClick(wordPart.id)}>{wordPart.label}</button>
       ))}
-      <hr/>
+
+      <hr />
+
       {selectedWordPart &&
-        <WordPartDetail wordPart={selectedWordPart} onNeedsWork={handleNeedsWork} onMastered={handleMastered}/>}
+        <WordPartDetail
+          wordPart={selectedWordPart}
+          onNeedsWork={handleNeedsWork}
+          onMastered={handleMastered} />}
+
+      {isErrorMutation && <div className="mr-2 mb-2 px-2 py-1 border rounded hover:bg-gray-200 text-center" > Error updating word part status</div>}
     </div>
   );
 };
-
-export default WordPartsList;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,9 +2,14 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/client/src/queries/levels.query.ts
+++ b/client/src/queries/levels.query.ts
@@ -1,5 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Level } from "../types/Level";
+import { WordPart } from "../types/WordPart";
 
 /** 
  * Fetch phonics levels from the API 

--- a/client/src/queries/levels.ts
+++ b/client/src/queries/levels.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { Level } from "../types/Level";
+
+/** 
+ * Fetch phonics levels from the API 
+ */
+export const fetchLevels = async (): Promise<Level[]> => {
+  const response = await fetch("/phonics_levels");
+
+  if (!response.ok) {
+    throw new Error("Network response was not ok");
+  }
+
+  return await response.json();
+}
+
+/** 
+ * Custom hook to fetch phonics levels
+ */
+export const useLevels = () => useQuery<Level[]>({
+  queryKey: ["LEVELS"],
+  queryFn: fetchLevels,
+});

--- a/client/src/queries/wordPart.query.ts
+++ b/client/src/queries/wordPart.query.ts
@@ -27,7 +27,7 @@ export const fetchWordParts = async (levelId: number): Promise<WordPart[]> => {
  */
 export const useWordParts = (levelId: number) =>
     useQuery<WordPart[]>({
-        queryKey: ['WORD_PARTS', levelId],
+        queryKey: [`WORD_PARTS_${levelId}`],
         queryFn: () => fetchWordParts(levelId),
     });
 

--- a/client/src/queries/wordPart.query.ts
+++ b/client/src/queries/wordPart.query.ts
@@ -1,0 +1,59 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { WordPart } from "../types/WordPart";
+
+/**
+ *  Fetch word parts for a given phonics level from the API
+ * 
+ * @param levelId - the id of the phonics level
+ * @returns  the word parts for the given phonics level
+ */
+export const fetchWordParts = async (levelId: number): Promise<WordPart[]> => {
+    const response = await fetch(`/phonics_levels/${levelId}/word_parts`);
+
+    if (!response.ok) {
+        throw new Error("Network response was not ok");
+    }
+
+    return await response.json();
+}
+
+
+/**
+ *  Custom hook to fetch word parts for a given phonics level
+ * 
+ * @param levelId - the id of the phonics level
+ * @returns the word parts for the given phonics level
+ */
+export const useWordParts = (levelId: number) =>
+    useQuery<WordPart[]>({
+        queryKey: ['WORD_PARTS', levelId],
+        queryFn: () => fetchWordParts(levelId),
+    });
+
+
+/**
+ *  Custom hook to mutate (update) a word part for a given phonics level
+ * 
+ * @param levelId  - the id of the phonics level
+ * @returns the mutation object
+ * 
+ */
+export const useWordPartMut = () => useMutation({
+
+    mutationFn: async (wordPart: WordPart) => {
+        const response = await fetch(`/phonics_levels/${wordPart.phonics_level_id}/word_parts/${wordPart.id}`, {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(wordPart),
+        });
+
+        if (!response.ok) {
+            throw new Error("Network response was not ok");
+        }
+
+        return await response.json();
+    },
+});

--- a/client/src/types/WordPart.ts
+++ b/client/src/types/WordPart.ts
@@ -2,4 +2,5 @@ export type WordPart = {
   id: number;
   label: string;
   status?: "mastered" | "needs_practice";
+  phonics_level_id: number;
 }

--- a/client/src/types/WordPart.ts
+++ b/client/src/types/WordPart.ts
@@ -1,6 +1,6 @@
 export type WordPart = {
   id: number;
   label: string;
-  status?: "mastered" | "needs_practice";
+  status?: "mastered" | "needs_work";
   phonics_level_id: number;
 }

--- a/server/app/controllers/word_parts_controller.rb
+++ b/server/app/controllers/word_parts_controller.rb
@@ -4,4 +4,14 @@ class WordPartsController < ApplicationController
 
     render json: @phonics_level.word_parts
   end
+
+  def update
+    @word_part = WordPart.find(params[:id])
+
+    if @word_part.update({ status: params[:status] })
+      render json: @word_part
+    else
+      render json: { errors: @word_part.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
 end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resources :phonics_levels, only: [ :index ] do
-    resources :word_parts, only: [ :index ]
+    resources :word_parts, only: [ :index, :update ]
   end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
- Added Rect Query to simplify API requests
- Handle the User responses

Proposal for changes

- The level selector was different from butons so I have moved the selector to have the same look and feel to unify the user experience.
<img width="591" height="555" alt="Screenshot 2025-09-28 at 12 41 59 PM" src="https://github.com/user-attachments/assets/65e7837f-aa21-412a-8162-90c543e5335e" />
